### PR TITLE
Update validator slashing to reflect new slashing rules.

### DIFF
--- a/v1.0.0/concepts/rewards-and-slashing.mdx
+++ b/v1.0.0/concepts/rewards-and-slashing.mdx
@@ -32,9 +32,7 @@ A proposer can completely miss its slot and not include any block in L1. This ca
 
     2. The proposer includes a block that was built by itself.
     
-Case (1) is considered non-compliant behavior and thus the proposer will be slashed from their stake the fixed amount of 1 ETH.  
-  
-Case (2) should only happen very rarely when the value of the block it receives from the relay is too low, and mev-commit will not slash proposers in this case. However, due to the lack of a robust mechanism for builder attribution of a block in Ethereum's PBS, we will monitor how often proposers choose to build their own blocks, and if needed we will revisit this decision to discourage misbehavior by the proposers.
+Both cases are considered non-compliant behavior and thus the proposer will be slashed from their stake the fixed amount of 1 ETH.
 
 Currently, the restaking case with Eigenlayer only allows the stake to be frozen for an undetermined period of time and not slashed permanently (i.e., burned). While the stake is frozen, the proposer is not able to participate in mev-commit. The proposer can pay a fee to unfreeze its stake. This is a limitation of the current Eigenlayer implementation, and it is expected to be resolved. 
 

--- a/v1.0.0/concepts/validator-considerations.mdx
+++ b/v1.0.0/concepts/validator-considerations.mdx
@@ -16,7 +16,7 @@ Opting into the mev-commit protocol signals from a validator that they:
 Validators opting into the mev-commit protocol should be aware of the following risks:
 
 * **Relay block delivery:** Relays could communicate blocks that do not abide by existing commitments. This would lead to slashing of the validator.
-* **Failure to propose block:** Validators could fail to propose a block for a slot that has preconf commitments. This would lead to slashing of the validator if there are existing commitments
+* **Self-building a block:** A validator gets slashed when it self-builds a block. When the min-bid parameter of mev-boost is set to 0, this can happen only if no block is received from any of the connected relays, which should never happen in normal circumstances.
 
 ### Future plans
 

--- a/v1.0.0/get-started/validators/validator-guide.mdx
+++ b/v1.0.0/get-started/validators/validator-guide.mdx
@@ -8,17 +8,21 @@ description: 'Opt into mev-commit with ease. This guide covers everything you ne
 
 Participation of L1 validators in the mev-commit protocol increases the credibility of preconfs made through mev-commit and consequently their value. Due to increased preconf values, providers have additional value to bid in the mev-boost auction, thus driving up the total revenue a proposer will get.
 
-## Requirements
+## Prerequisites
 
 1. An operational L1 validator node.
 2. An operational mev-boost sidecar.
-3. Stake or Restake as described below.
+
+## Steps to Opt in
+1. Stake or Restake as described below.
+2. Configure mev-boost to only connect to mev-commit opted-in relays.
+3. Configure mev-boost with min-bid 0.
 
 <Warning>
-As a validator opting into the mev-commit protocol, ensure your mev-boost client only connects to mev-commit opted-in relays to avoid slashing for proposing blocks without delivering commitments.
+As a validator opting into the mev-commit protocol, ensure your mev-boost client is configured with min-bid 0 and only connects to mev-commit opted-in relays to avoid slashing for proposing blocks without delivering commitments.
 </Warning>
 
-By opting-in to the mev-commit protocol as a validator **in one of the three forms described**, you agree to only use **opted-in relays**. These opted-in relays will only forward mev-boost bids from addresses that have registered with the mev-commit provider registry, such that providers can be slashed in case of a protocol violation. We generally don't anticipate validator slashing events, as this allows validators to passively opt-in to mev-commit, letting block builders and relays do the work.
+By opting-in to the mev-commit protocol as a validator **in one of the three forms described**, you agree to not self build blocks by setting the min-bid parameter to 0 and to only use **opted-in relays**. These opted-in relays will only forward mev-boost bids from addresses that have registered with the mev-commit provider registry. These two steps ensure that the validator only proposes blocks from registered block builders such that these builders can be slashed in case of a protocol violation. We generally don't anticipate validator slashing events, as this allows validators to passively opt-in to mev-commit, letting block builders and relays do the work.
 
 ### Supporting Relays
 


### PR DESCRIPTION
We are moving to a stricter opt in for validators to improve the robustness of commitments. This update to the docs reflects this change.