### PR TITLE
Add explicit formula for decayed bid.

### DIFF
--- a/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
+++ b/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
@@ -32,8 +32,9 @@ For example, if the decay proportion is $1/2$ as in the example above, the bid's
 
 In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider
 $$
-\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}}.
+\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
 $$
+where the amount is capped between $0$ and $\mathrm{bidAmt}$.
 
 ## Analysis of the Mechanism
 

--- a/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
+++ b/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
@@ -30,11 +30,6 @@ The bid's value decreases linearly from the moment it is issued until its expiry
 
 For example, if the decay proportion is $1/2$ as in the example above, the bid's value decays by $50$%.
 
-In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider
-$$
-\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
-$$
-where the amount is capped between $0$ and $\mathrm{bidAmt}$.
 
 ## Analysis of the Mechanism
 

--- a/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
+++ b/archived-versions/v0.6.3/concepts/bids/bid-decay-mechanism.mdx
@@ -30,6 +30,10 @@ The bid's value decreases linearly from the moment it is issued until its expiry
 
 For example, if the decay proportion is $1/2$ as in the example above, the bid's value decays by $50$%.
 
+In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider
+$$
+\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}}.
+$$
 
 ## Analysis of the Mechanism
 

--- a/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
+++ b/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
@@ -30,11 +30,11 @@ The bid's value decreases linearly from the moment it is issued until its expiry
 
 For example, if the decay proportion is $1/2$ as in the example above, the bid's value decays by $50$%.
 
-In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider
+In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider the value~$v$ computed as
 $$
-\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
+v = \mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
 $$
-where the amount is capped between $0$ and $\mathrm{bidAmt}$.
+constraint to $0 \leq v \leq \mathrm{bidAmt}$, i.e., the value $v$ paid is never more than $\mathrm{bidAmt}$.
 
 ## Analysis of the Mechanism
 

--- a/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
+++ b/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
@@ -30,6 +30,11 @@ The bid's value decreases linearly from the moment it is issued until its expiry
 
 For example, if the decay proportion is $1/2$ as in the example above, the bid's value decays by $50$%.
 
+In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider
+$$
+\mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
+$$
+where the amount is capped between $0$ and $\mathrm{bidAmt}$.
 
 ## Analysis of the Mechanism
 

--- a/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
+++ b/v1.1.0/concepts/bids/bid-decay-mechanism.mdx
@@ -30,7 +30,7 @@ The bid's value decreases linearly from the moment it is issued until its expiry
 
 For example, if the decay proportion is $1/2$ as in the example above, the bid's value decays by $50$%.
 
-In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider the value~$v$ computed as
+In general, when a provider issues a commitment at time $t$ for a bid with amount $\mathrm{bidAmt}$, the bidder pays the provider the value $v$ computed as
 $$
 v = \mathrm{bidAmt} \cdot \frac{\mathrm{decayEndTimestamp} - t}{\mathrm{decayEndTimestamp} - \mathrm{decayStartTimestamp}},
 $$


### PR DESCRIPTION
This PR adds an explicit formula to the decay page of the docs that allows one to compute the amount paid by the bidder for commitments given at a certain time.